### PR TITLE
passing query options now possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,18 @@
 var riot = require('riot')
 var pug = require('pug')
+var loaderUtils = require("loader-utils")
 
 module.exports = function(source) {
-  source = pug.render(source, { pretty: true })
+  var options = { pretty: true },
+      config = {},
+      query = loaderUtils.parseQuery(this.query)
+  ;
+  Object.keys(query).forEach(function(attr) {
+  	config[attr] = query[attr];
+  });
+  options = Object.assign(options, config)
+
+  source = pug.render(source, options)
   return 'var riot = require("riot");\n\n' + riot.compile(source)
 };
+


### PR DESCRIPTION
Hello,

I was having trouble in using `include file.pug`, it gave me errors not finding the file.
I needed to pass in the basedir options but the way it was it was not possible, so I added this feature.

Now I'm able to configure basedir as `tag-pug?basedir=/m/dir` and it passes along to `pug.render()` call.

I'm sharing the modifications, ( sorry in commit comments I mistyped tag-pug as pug-tag, my bad.)

thanks for the original loader.

regards.

Rafael